### PR TITLE
Wandering NPCs

### DIFF
--- a/scenes/NPC.tscn
+++ b/scenes/NPC.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=16 format=2]
+[gd_scene load_steps=31 format=2]
 
 [ext_resource path="res://assets/01_characters/03_pnjs/frederiqueTruschel-Sheet.png" type="Texture" id=1]
 [ext_resource path="res://src/NPC.cs" type="Script" id=2]
@@ -14,7 +14,7 @@ height = 6.0
 radius = 12.0416
 
 [sub_resource type="Animation" id=3]
-resource_name = "Idle"
+resource_name = "IdleDown"
 loop = true
 tracks/0/type = "value"
 tracks/0/path = NodePath("FullyAnimated:frame")
@@ -27,6 +27,18 @@ tracks/0/keys = {
 "transitions": PoolRealArray( 1, 1 ),
 "update": 1,
 "values": [ 0, 1 ]
+}
+tracks/1/type = "value"
+tracks/1/path = NodePath("FullyAnimated:flip_h")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/keys = {
+"times": PoolRealArray( 0 ),
+"transitions": PoolRealArray( 1 ),
+"update": 1,
+"values": [ false ]
 }
 
 [sub_resource type="Animation" id=4]
@@ -43,6 +55,18 @@ tracks/0/keys = {
 "transitions": PoolRealArray( 1, 1 ),
 "update": 1,
 "values": [ 4, 5 ]
+}
+tracks/1/type = "value"
+tracks/1/path = NodePath("FullyAnimated:flip_h")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/keys = {
+"times": PoolRealArray( 0 ),
+"transitions": PoolRealArray( 1 ),
+"update": 1,
+"values": [ false ]
 }
 
 [sub_resource type="Animation" id=5]
@@ -74,6 +98,34 @@ tracks/1/keys = {
 "values": [ 4, 5 ]
 }
 
+[sub_resource type="Animation" id=39]
+resource_name = "IdleUp"
+length = 0.4
+tracks/0/type = "value"
+tracks/0/path = NodePath("FullyAnimated:flip_h")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/keys = {
+"times": PoolRealArray( 0 ),
+"transitions": PoolRealArray( 1 ),
+"update": 1,
+"values": [ false ]
+}
+tracks/1/type = "value"
+tracks/1/path = NodePath("FullyAnimated:frame")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/keys = {
+"times": PoolRealArray( 0, 0.2 ),
+"transitions": PoolRealArray( 1, 1 ),
+"update": 1,
+"values": [ 8, 9 ]
+}
+
 [sub_resource type="Animation" id=6]
 length = 0.001
 tracks/0/type = "value"
@@ -88,10 +140,22 @@ tracks/0/keys = {
 "update": 0,
 "values": [ 1 ]
 }
+tracks/1/type = "value"
+tracks/1/path = NodePath("FullyAnimated:flip_h")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/keys = {
+"times": PoolRealArray( 0 ),
+"transitions": PoolRealArray( 1 ),
+"update": 0,
+"values": [ false ]
+}
 
 [sub_resource type="Animation" id=7]
 resource_name = "WalkDown"
-length = 0.4
+length = 0.8
 loop = true
 tracks/0/type = "value"
 tracks/0/path = NodePath("FullyAnimated:frame")
@@ -100,15 +164,27 @@ tracks/0/loop_wrap = true
 tracks/0/imported = false
 tracks/0/enabled = true
 tracks/0/keys = {
-"times": PoolRealArray( 0, 0.1, 0.2, 0.3 ),
+"times": PoolRealArray( 0, 0.2, 0.4, 0.6 ),
 "transitions": PoolRealArray( 1, 1, 1, 1 ),
 "update": 1,
 "values": [ 2, 1, 3, 1 ]
 }
+tracks/1/type = "value"
+tracks/1/path = NodePath("FullyAnimated:flip_h")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/keys = {
+"times": PoolRealArray( 0 ),
+"transitions": PoolRealArray( 1 ),
+"update": 1,
+"values": [ false ]
+}
 
 [sub_resource type="Animation" id=8]
 resource_name = "WalkLeft"
-length = 0.4
+length = 0.8
 loop = true
 tracks/0/type = "value"
 tracks/0/path = NodePath("FullyAnimated:frame")
@@ -117,15 +193,27 @@ tracks/0/loop_wrap = true
 tracks/0/imported = false
 tracks/0/enabled = true
 tracks/0/keys = {
-"times": PoolRealArray( 0, 0.1, 0.2, 0.3 ),
+"times": PoolRealArray( 0, 0.2, 0.4, 0.6 ),
 "transitions": PoolRealArray( 1, 1, 1, 1 ),
 "update": 1,
 "values": [ 5, 6, 5, 7 ]
 }
+tracks/1/type = "value"
+tracks/1/path = NodePath("FullyAnimated:flip_h")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/keys = {
+"times": PoolRealArray( 0 ),
+"transitions": PoolRealArray( 1 ),
+"update": 1,
+"values": [ false ]
+}
 
 [sub_resource type="Animation" id=9]
 resource_name = "WalkRight"
-length = 0.4
+length = 0.8
 loop = true
 tracks/0/type = "value"
 tracks/0/path = NodePath("FullyAnimated:frame")
@@ -134,7 +222,7 @@ tracks/0/loop_wrap = true
 tracks/0/imported = false
 tracks/0/enabled = true
 tracks/0/keys = {
-"times": PoolRealArray( 0, 0.1, 0.2, 0.3 ),
+"times": PoolRealArray( 0, 0.2, 0.4, 0.6 ),
 "transitions": PoolRealArray( 1, 1, 1, 1 ),
 "update": 1,
 "values": [ 5, 6, 5, 7 ]
@@ -154,20 +242,93 @@ tracks/1/keys = {
 
 [sub_resource type="Animation" id=10]
 resource_name = "WalkUp"
-length = 0.4
+length = 0.8
 loop = true
 tracks/0/type = "value"
-tracks/0/path = NodePath("FullyAnimated:frame")
+tracks/0/path = NodePath("FullyAnimated:flip_h")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
 tracks/0/imported = false
 tracks/0/enabled = true
 tracks/0/keys = {
-"times": PoolRealArray( 0, 0.1, 0.2, 0.3 ),
+"times": PoolRealArray( 0 ),
+"transitions": PoolRealArray( 1 ),
+"update": 1,
+"values": [ false ]
+}
+tracks/1/type = "value"
+tracks/1/path = NodePath("FullyAnimated:frame")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/keys = {
+"times": PoolRealArray( 0, 0.2, 0.4, 0.6 ),
 "transitions": PoolRealArray( 1, 1, 1, 1 ),
 "update": 1,
-"values": [ 8, 9, 8, 10 ]
+"values": [ 9, 10, 9, 11 ]
 }
+
+[sub_resource type="AnimationNodeAnimation" id=40]
+animation = "IdleDown"
+
+[sub_resource type="AnimationNodeAnimation" id=41]
+animation = "IdleLeft"
+
+[sub_resource type="AnimationNodeAnimation" id=42]
+animation = "IdleUp"
+
+[sub_resource type="AnimationNodeAnimation" id=43]
+animation = "IdleRight"
+
+[sub_resource type="AnimationNodeBlendSpace2D" id=20]
+blend_point_0/node = SubResource( 40 )
+blend_point_0/pos = Vector2( 0, 1 )
+blend_point_1/node = SubResource( 41 )
+blend_point_1/pos = Vector2( -1, 0 )
+blend_point_2/node = SubResource( 42 )
+blend_point_2/pos = Vector2( 0, -1 )
+blend_point_3/node = SubResource( 43 )
+blend_point_3/pos = Vector2( 1, 0 )
+blend_mode = 1
+
+[sub_resource type="AnimationNodeAnimation" id=44]
+animation = "WalkDown"
+
+[sub_resource type="AnimationNodeAnimation" id=45]
+animation = "WalkUp"
+
+[sub_resource type="AnimationNodeAnimation" id=46]
+animation = "WalkLeft"
+
+[sub_resource type="AnimationNodeAnimation" id=47]
+animation = "WalkRight"
+
+[sub_resource type="AnimationNodeBlendSpace2D" id=30]
+blend_point_0/node = SubResource( 44 )
+blend_point_0/pos = Vector2( 0, 1 )
+blend_point_1/node = SubResource( 45 )
+blend_point_1/pos = Vector2( 0, -1 )
+blend_point_2/node = SubResource( 46 )
+blend_point_2/pos = Vector2( -1, 0 )
+blend_point_3/node = SubResource( 47 )
+blend_point_3/pos = Vector2( 1, 0 )
+blend_mode = 1
+
+[sub_resource type="AnimationNodeStateMachineTransition" id=31]
+
+[sub_resource type="AnimationNodeStateMachineTransition" id=38]
+
+[sub_resource type="AnimationNodeStateMachine" id=48]
+states/Idle/node = SubResource( 20 )
+states/Idle/position = Vector2( 320.5, 125.375 )
+states/Walk/node = SubResource( 30 )
+states/Walk/position = Vector2( 653, 125 )
+transitions = [ "Idle", "Walk", SubResource( 31 ), "Walk", "Idle", SubResource( 38 ) ]
+start_node = "Idle"
+graph_offset = Vector2( -36.2373, 86.6925 )
+
+[sub_resource type="AnimationNodeStateMachinePlayback" id=49]
 
 [node name="NPC" type="KinematicBody2D"]
 script = ExtResource( 2 )
@@ -184,7 +345,6 @@ texture = ExtResource( 5 )
 [node name="FullyAnimated" type="Sprite" parent="."]
 position = Vector2( 0, -7 )
 texture = ExtResource( 1 )
-flip_h = true
 hframes = 4
 vframes = 3
 frame = 1
@@ -200,14 +360,22 @@ shape = SubResource( 1 )
 shape = SubResource( 2 )
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="."]
-anims/Idle = SubResource( 3 )
+anims/IdleDown = SubResource( 3 )
 anims/IdleLeft = SubResource( 4 )
 anims/IdleRight = SubResource( 5 )
+anims/IdleUp = SubResource( 39 )
 anims/RESET = SubResource( 6 )
 anims/WalkDown = SubResource( 7 )
 anims/WalkLeft = SubResource( 8 )
 anims/WalkRight = SubResource( 9 )
 anims/WalkUp = SubResource( 10 )
+
+[node name="AnimationTree" type="AnimationTree" parent="."]
+tree_root = SubResource( 48 )
+anim_player = NodePath("../AnimationPlayer")
+parameters/playback = SubResource( 49 )
+parameters/Idle/blend_position = Vector2( 0, 0 )
+parameters/Walk/blend_position = Vector2( 0, 0 )
 
 [connection signal="area_entered" from="ListenBox" to="." method="_on_ListenBox_area_entered"]
 [connection signal="area_exited" from="ListenBox" to="." method="_on_ListenBox_area_exited"]

--- a/scenes/NPC.tscn
+++ b/scenes/NPC.tscn
@@ -43,7 +43,7 @@ tracks/1/keys = {
 
 [sub_resource type="Animation" id=4]
 resource_name = "IdleLeft"
-length = 0.4
+loop = true
 tracks/0/type = "value"
 tracks/0/path = NodePath("FullyAnimated:frame")
 tracks/0/interp = 1
@@ -51,7 +51,7 @@ tracks/0/loop_wrap = true
 tracks/0/imported = false
 tracks/0/enabled = true
 tracks/0/keys = {
-"times": PoolRealArray( 0, 0.2 ),
+"times": PoolRealArray( 0, 0.5 ),
 "transitions": PoolRealArray( 1, 1 ),
 "update": 1,
 "values": [ 4, 5 ]
@@ -71,7 +71,6 @@ tracks/1/keys = {
 
 [sub_resource type="Animation" id=5]
 resource_name = "IdleRight"
-length = 0.4
 loop = true
 tracks/0/type = "value"
 tracks/0/path = NodePath("FullyAnimated:flip_h")
@@ -92,7 +91,7 @@ tracks/1/loop_wrap = true
 tracks/1/imported = false
 tracks/1/enabled = true
 tracks/1/keys = {
-"times": PoolRealArray( 0, 0.2 ),
+"times": PoolRealArray( 0, 0.5 ),
 "transitions": PoolRealArray( 1, 1 ),
 "update": 1,
 "values": [ 4, 5 ]
@@ -100,7 +99,7 @@ tracks/1/keys = {
 
 [sub_resource type="Animation" id=39]
 resource_name = "IdleUp"
-length = 0.4
+loop = true
 tracks/0/type = "value"
 tracks/0/path = NodePath("FullyAnimated:flip_h")
 tracks/0/interp = 1
@@ -120,7 +119,7 @@ tracks/1/loop_wrap = true
 tracks/1/imported = false
 tracks/1/enabled = true
 tracks/1/keys = {
-"times": PoolRealArray( 0, 0.2 ),
+"times": PoolRealArray( 0, 0.5 ),
 "transitions": PoolRealArray( 1, 1 ),
 "update": 1,
 "values": [ 8, 9 ]
@@ -326,7 +325,7 @@ states/Walk/node = SubResource( 30 )
 states/Walk/position = Vector2( 653, 125 )
 transitions = [ "Idle", "Walk", SubResource( 31 ), "Walk", "Idle", SubResource( 38 ) ]
 start_node = "Idle"
-graph_offset = Vector2( -36.2373, 86.6925 )
+graph_offset = Vector2( -90.6573, 2.58748 )
 
 [sub_resource type="AnimationNodeStateMachinePlayback" id=49]
 

--- a/scenes/Palud/ProtoPalud.tscn
+++ b/scenes/Palud/ProtoPalud.tscn
@@ -501,6 +501,9 @@ position = Vector2( 55, 193 )
 [node name="Label" parent="YSort/Props/Item/Sprite" index="0"]
 text = "Regarder"
 
+[node name="AnimatedSprite" parent="YSort/Props/Item/Sprite" index="1"]
+frame = 0
+
 [node name="AffichePlaceholder" type="ColorRect" parent="YSort/Props"]
 margin_left = 45.0
 margin_top = 184.0

--- a/scenes/Palud/ProtoPalud.tscn
+++ b/scenes/Palud/ProtoPalud.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=49 format=2]
+[gd_scene load_steps=59 format=2]
 
 [ext_resource path="res://scenes/Player.tscn" type="PackedScene" id=1]
 [ext_resource path="res://assets/02_architecture/02_palud/backgroundPalud.png" type="Texture" id=3]
@@ -101,6 +101,22 @@ b = Vector2( 642.831, 1.25632 )
 [sub_resource type="SegmentShape2D" id=3]
 a = Vector2( 7.58701, -140.561 )
 b = Vector2( 7.2533, 11.611 )
+
+[sub_resource type="AnimationNodeStateMachinePlayback" id=15]
+
+[sub_resource type="AnimationNodeStateMachinePlayback" id=16]
+
+[sub_resource type="AnimationNodeStateMachinePlayback" id=17]
+
+[sub_resource type="AnimationNodeStateMachinePlayback" id=18]
+
+[sub_resource type="AnimationNodeStateMachinePlayback" id=19]
+
+[sub_resource type="AnimationNodeStateMachinePlayback" id=20]
+
+[sub_resource type="AnimationNodeStateMachinePlayback" id=21]
+
+[sub_resource type="AnimationNodeStateMachinePlayback" id=22]
 
 [sub_resource type="Animation" id=7]
 resource_name = "Idle"
@@ -258,6 +274,10 @@ tracks/0/keys = {
 "update": 1,
 "values": [ 8, 9, 8, 10 ]
 }
+
+[sub_resource type="AnimationNodeStateMachinePlayback" id=23]
+
+[sub_resource type="AnimationNodeStateMachinePlayback" id=24]
 
 [sub_resource type="Animation" id=5]
 length = 0.001
@@ -500,12 +520,16 @@ texture = ExtResource( 22 )
 
 [node name="Truschel" parent="YSort/NPC" instance=ExtResource( 8 )]
 position = Vector2( 121, 333 )
+CanWander = true
 AutoDialogueID = ""
 DemandDialogueID = "demandTruschel"
 HasAutoDialogue = false
 
 [node name="ListenBox" parent="YSort/NPC/Truschel" index="4"]
 visible = false
+
+[node name="AnimationTree" parent="YSort/NPC/Truschel" index="6"]
+parameters/playback = SubResource( 15 )
 
 [node name="Baker" parent="YSort/NPC" instance=ExtResource( 8 )]
 position = Vector2( 147, 228 )
@@ -518,6 +542,9 @@ position = Vector2( -13.8276, -35.652 )
 [node name="FullyAnimated" parent="YSort/NPC/Baker" index="2"]
 texture = ExtResource( 32 )
 
+[node name="AnimationTree" parent="YSort/NPC/Baker" index="6"]
+parameters/playback = SubResource( 16 )
+
 [node name="Baker3" parent="YSort/NPC" instance=ExtResource( 8 )]
 position = Vector2( 29, 278 )
 AutoDialogueID = "testApproach"
@@ -528,6 +555,9 @@ position = Vector2( -13.8276, -35.652 )
 
 [node name="FullyAnimated" parent="YSort/NPC/Baker3" index="2"]
 texture = ExtResource( 32 )
+
+[node name="AnimationTree" parent="YSort/NPC/Baker3" index="6"]
+parameters/playback = SubResource( 17 )
 
 [node name="Baker2" parent="YSort/NPC" instance=ExtResource( 8 )]
 position = Vector2( 453, 298 )
@@ -540,8 +570,12 @@ position = Vector2( -13.8276, -35.652 )
 [node name="FullyAnimated" parent="YSort/NPC/Baker2" index="2"]
 texture = ExtResource( 32 )
 
+[node name="AnimationTree" parent="YSort/NPC/Baker2" index="6"]
+parameters/playback = SubResource( 18 )
+
 [node name="Elisabeth" parent="YSort/NPC" instance=ExtResource( 8 )]
 position = Vector2( 190, 295 )
+CanWander = true
 AutoDialogueID = ""
 DemandDialogueID = "demandElisabeth"
 HasAutoDialogue = false
@@ -561,8 +595,12 @@ visible = false
 [node name="CollisionShape2D" parent="YSort/NPC/Elisabeth/ListenBox" index="0"]
 visible = false
 
+[node name="AnimationTree" parent="YSort/NPC/Elisabeth" index="6"]
+parameters/playback = SubResource( 19 )
+
 [node name="Random" parent="YSort/NPC" instance=ExtResource( 8 )]
 position = Vector2( 259, 204 )
+CanWander = true
 AutoDialogueID = ""
 DemandDialogueID = "demandPasteur"
 HasAutoDialogue = false
@@ -582,8 +620,12 @@ visible = false
 [node name="CollisionShape2D" parent="YSort/NPC/Random/ListenBox" index="0"]
 visible = false
 
+[node name="AnimationTree" parent="YSort/NPC/Random" index="6"]
+parameters/playback = SubResource( 20 )
+
 [node name="OldMan" parent="YSort/NPC" instance=ExtResource( 8 )]
 position = Vector2( 301, 332 )
+CanWander = true
 AutoDialogueID = ""
 DemandDialogueID = "demandOldMan"
 HasAutoDialogue = false
@@ -597,6 +639,9 @@ texture = ExtResource( 13 )
 [node name="ListenBox" parent="YSort/NPC/OldMan" index="4"]
 visible = false
 
+[node name="AnimationTree" parent="YSort/NPC/OldMan" index="6"]
+parameters/playback = SubResource( 21 )
+
 [node name="Lingere" parent="YSort/NPC" instance=ExtResource( 8 )]
 position = Vector2( 330, 257 )
 HasAutoDialogue = false
@@ -608,9 +653,11 @@ position = Vector2( 2, 4 )
 
 [node name="FullyAnimated" parent="YSort/NPC/Lingere" index="2"]
 texture = ExtResource( 36 )
-flip_h = false
 hframes = 2
 vframes = 1
+
+[node name="AnimationTree" parent="YSort/NPC/Lingere" index="6"]
+parameters/playback = SubResource( 22 )
 
 [node name="Lingere2" parent="YSort/NPC" instance=ExtResource( 8 )]
 position = Vector2( 247, 265 )
@@ -634,6 +681,9 @@ anims/WalkDown = SubResource( 11 )
 anims/WalkLeft = SubResource( 12 )
 anims/WalkRight = SubResource( 13 )
 anims/WalkUp = SubResource( 14 )
+
+[node name="AnimationTree" parent="YSort/NPC/Lingere2" index="6"]
+parameters/playback = SubResource( 23 )
 
 [node name="Fountain" parent="YSort" instance=ExtResource( 11 )]
 position = Vector2( 339, 256 )
@@ -675,6 +725,9 @@ texture = ExtResource( 34 )
 
 [node name="ListenBox" parent="YSort/QuestNPC" index="4"]
 visible = false
+
+[node name="AnimationTree" parent="YSort/QuestNPC" index="6"]
+parameters/playback = SubResource( 24 )
 
 [node name="Notebook" parent="." instance=ExtResource( 15 )]
 visible = false

--- a/scenes/Palud/ProtoPalud.tscn
+++ b/scenes/Palud/ProtoPalud.tscn
@@ -603,6 +603,8 @@ parameters/playback = SubResource( 19 )
 
 [node name="Random" parent="YSort/NPC" instance=ExtResource( 8 )]
 position = Vector2( 259, 204 )
+ProbUp = 0
+ProbDown = 0
 CanWander = true
 AutoDialogueID = ""
 DemandDialogueID = "demandPasteur"
@@ -627,7 +629,11 @@ visible = false
 parameters/playback = SubResource( 20 )
 
 [node name="OldMan" parent="YSort/NPC" instance=ExtResource( 8 )]
-position = Vector2( 301, 332 )
+position = Vector2( 301, 325 )
+ProbRight = 1
+ProbLeft = 1
+ProbUp = 0
+ProbDown = 0
 CanWander = true
 AutoDialogueID = ""
 DemandDialogueID = "demandOldMan"

--- a/scenes/Palud/ProtoPalud.tscn
+++ b/scenes/Palud/ProtoPalud.tscn
@@ -501,9 +501,6 @@ position = Vector2( 55, 193 )
 [node name="Label" parent="YSort/Props/Item/Sprite" index="0"]
 text = "Regarder"
 
-[node name="AnimatedSprite" parent="YSort/Props/Item/Sprite" index="1"]
-frame = 0
-
 [node name="AffichePlaceholder" type="ColorRect" parent="YSort/Props"]
 margin_left = 45.0
 margin_top = 184.0

--- a/scenes/Player.tscn
+++ b/scenes/Player.tscn
@@ -384,72 +384,72 @@ tracks/1/keys = {
 "values": [ 10, 8, 11, 8 ]
 }
 
-[sub_resource type="AnimationNodeAnimation" id=16]
+[sub_resource type="AnimationNodeAnimation" id=40]
 animation = "IdleDown"
 
-[sub_resource type="AnimationNodeAnimation" id=17]
+[sub_resource type="AnimationNodeAnimation" id=41]
 animation = "IdleLeft"
 
-[sub_resource type="AnimationNodeAnimation" id=18]
+[sub_resource type="AnimationNodeAnimation" id=42]
 animation = "IdleUp"
 
-[sub_resource type="AnimationNodeAnimation" id=19]
+[sub_resource type="AnimationNodeAnimation" id=43]
 animation = "IdleRight"
 
 [sub_resource type="AnimationNodeBlendSpace2D" id=20]
-blend_point_0/node = SubResource( 16 )
+blend_point_0/node = SubResource( 40 )
 blend_point_0/pos = Vector2( 0, 1 )
-blend_point_1/node = SubResource( 17 )
+blend_point_1/node = SubResource( 41 )
 blend_point_1/pos = Vector2( -1, 0 )
-blend_point_2/node = SubResource( 18 )
+blend_point_2/node = SubResource( 42 )
 blend_point_2/pos = Vector2( 0, -1 )
-blend_point_3/node = SubResource( 19 )
+blend_point_3/node = SubResource( 43 )
 blend_point_3/pos = Vector2( 1, 0 )
 blend_mode = 1
 
-[sub_resource type="AnimationNodeAnimation" id=21]
+[sub_resource type="AnimationNodeAnimation" id=48]
 animation = "RunDown"
 
-[sub_resource type="AnimationNodeAnimation" id=22]
+[sub_resource type="AnimationNodeAnimation" id=49]
 animation = "RunUp"
 
-[sub_resource type="AnimationNodeAnimation" id=23]
+[sub_resource type="AnimationNodeAnimation" id=50]
 animation = "RunLeft"
 
-[sub_resource type="AnimationNodeAnimation" id=24]
+[sub_resource type="AnimationNodeAnimation" id=51]
 animation = "RunRight"
 
 [sub_resource type="AnimationNodeBlendSpace2D" id=25]
-blend_point_0/node = SubResource( 21 )
+blend_point_0/node = SubResource( 48 )
 blend_point_0/pos = Vector2( 0, 1 )
-blend_point_1/node = SubResource( 22 )
+blend_point_1/node = SubResource( 49 )
 blend_point_1/pos = Vector2( 0, -1 )
-blend_point_2/node = SubResource( 23 )
+blend_point_2/node = SubResource( 50 )
 blend_point_2/pos = Vector2( -1, 0 )
-blend_point_3/node = SubResource( 24 )
+blend_point_3/node = SubResource( 51 )
 blend_point_3/pos = Vector2( 1, 0 )
 blend_mode = 1
 
-[sub_resource type="AnimationNodeAnimation" id=26]
+[sub_resource type="AnimationNodeAnimation" id=44]
 animation = "WalkDown"
 
-[sub_resource type="AnimationNodeAnimation" id=27]
+[sub_resource type="AnimationNodeAnimation" id=45]
 animation = "WalkUp"
 
-[sub_resource type="AnimationNodeAnimation" id=28]
+[sub_resource type="AnimationNodeAnimation" id=46]
 animation = "WalkLeft"
 
-[sub_resource type="AnimationNodeAnimation" id=29]
+[sub_resource type="AnimationNodeAnimation" id=47]
 animation = "WalkRight"
 
 [sub_resource type="AnimationNodeBlendSpace2D" id=30]
-blend_point_0/node = SubResource( 26 )
+blend_point_0/node = SubResource( 44 )
 blend_point_0/pos = Vector2( 0, 1 )
-blend_point_1/node = SubResource( 27 )
+blend_point_1/node = SubResource( 45 )
 blend_point_1/pos = Vector2( 0, -1 )
-blend_point_2/node = SubResource( 28 )
+blend_point_2/node = SubResource( 46 )
 blend_point_2/pos = Vector2( -1, 0 )
-blend_point_3/node = SubResource( 29 )
+blend_point_3/node = SubResource( 47 )
 blend_point_3/pos = Vector2( 1, 0 )
 blend_mode = 1
 

--- a/scenes/Player.tscn
+++ b/scenes/Player.tscn
@@ -306,10 +306,10 @@ tracks/0/loop_wrap = true
 tracks/0/imported = false
 tracks/0/enabled = true
 tracks/0/keys = {
-"times": PoolRealArray( 0, 0.15, 0.3, 0.45, 0.7 ),
-"transitions": PoolRealArray( 1, 1, 1, 1, 1 ),
+"times": PoolRealArray( 0, 0.15, 0.3, 0.45 ),
+"transitions": PoolRealArray( 1, 1, 1, 1 ),
 "update": 1,
-"values": [ 6, 5, 7, 5, 4 ]
+"values": [ 6, 5, 7, 5 ]
 }
 tracks/1/type = "value"
 tracks/1/path = NodePath("Sprite:flip_h")

--- a/src/NPC.cs
+++ b/src/NPC.cs
@@ -127,7 +127,7 @@ public class NPC : KinematicBody2D {
 	private Vector2 NewInputVec() {
 		int randXOffset = random.Next(2);
 		int randYOffset = random.Next(2);
-		return new Vector2(randXOffset - random.Next(3), randYOffset - random.Next(3));
+		return new Vector2(randXOffset - random.Next(2), randYOffset - random.Next(2));
 	}
 	
 	private void StopWandering() {

--- a/src/NPC.cs
+++ b/src/NPC.cs
@@ -144,6 +144,7 @@ public class NPC : KinematicBody2D {
 		isWandering = false;
 		InputVec = Vector2.Zero;
 		Velocity = Vector2.Zero;
+		AS.Travel("Idle");
 		
 		//Start cooldown
 		cooldown = (random.Next(100)/100.0f) * WanderingCooldown;
@@ -187,10 +188,7 @@ public class NPC : KinematicBody2D {
 		} else {
 			//Scale velocity and move
 			Velocity = MoveAndSlide(Velocity);
-			
-			/*if(GetSlideCount() > 0) {
-				StopWandering();
-			}*/
+			AS.Travel("Walk");
 		}
 	}
 	

--- a/src/NPC.cs
+++ b/src/NPC.cs
@@ -42,9 +42,9 @@ public class NPC : KinematicBody2D {
 	[Export]
 	public bool CanWander = false;
 	[Export]
-	public float WanderingCooldown = 10.0f;
+	public float WanderingCooldown = 5.0f;
 	[Export]
-	public float WanderingDist = 3.0f;
+	public float WanderingDist = 1.0f;
 	[Export]
 	public int WalkSpeed = 50;
 	[Export]
@@ -125,9 +125,9 @@ public class NPC : KinematicBody2D {
 	
 	//Generate a new random position within the wandering distance
 	private Vector2 NewInputVec() {
-		int randXOffset = random.Next(100);
-		int randYOffset = random.Next(100);
-		return new Vector2(randXOffset, randYOffset).Normalized();
+		int randXOffset = random.Next(2);
+		int randYOffset = random.Next(2);
+		return new Vector2(randXOffset - random.Next(3), randYOffset - random.Next(3));
 	}
 	
 	private void StopWandering() {
@@ -178,6 +178,10 @@ public class NPC : KinematicBody2D {
 		} else {
 			//Scale velocity and move
 			Velocity = MoveAndSlide(Velocity);
+			
+			/*if(GetSlideCount() > 0) {
+				StopWandering();
+			}*/
 		}
 	}
 	
@@ -205,8 +209,6 @@ public class NPC : KinematicBody2D {
 					TB._ShowText(next);
 				}
 			}
-		} else {
-			StopWandering();
 		}
 	}
 	
@@ -307,6 +309,12 @@ public class NPC : KinematicBody2D {
 				if(InnerLinesCount != 0) {
 					d = InnerLines[InnerLines.Length - InnerLinesCount--];
 				}
+				
+				//Turn to player
+				InputVec = (player.Position - Position).Normalized();
+				HandleMovement(0.03f);
+				InputVec = Vector2.Zero;
+				HandleMovement(0.03f);
 			}
 			
 			//Show it in the box

--- a/src/NPC.cs
+++ b/src/NPC.cs
@@ -40,6 +40,14 @@ public class NPC : KinematicBody2D {
 	private float wanderTime = 1.0f;
 	
 	[Export]
+	public int ProbRight = 2; //max weight of right movement
+	[Export]
+	public int ProbLeft = 2; //max weight of left movement
+	[Export]
+	public int ProbUp = 2; //max weight of up movement
+	[Export]
+	public int ProbDown = 2; //max weight of down movement
+	[Export]
 	public bool CanWander = false;
 	[Export]
 	public float WanderingCooldown = 5.0f;
@@ -125,9 +133,10 @@ public class NPC : KinematicBody2D {
 	
 	//Generate a new random position within the wandering distance
 	private Vector2 NewInputVec() {
-		int randXOffset = random.Next(2);
-		int randYOffset = random.Next(2);
-		return new Vector2(randXOffset - random.Next(2), randYOffset - random.Next(2));
+		return new Vector2(
+			random.Next(ProbRight) - random.Next(ProbLeft), 
+			random.Next(ProbDown) - random.Next(ProbUp)
+		);
 	}
 	
 	private void StopWandering() {


### PR DESCRIPTION
This PR adds movement to the NPCs. This means that they can now:  
  - Turn towards the player when being spoken to.  
  - Walk around the scene aimlessly.    
 
 This is done by activating the `Can Wander` in the NPCs that should wander. This is disabled by default.  
