### PR TITLE
Non-Wandering NPCs will turn back after speaking to the player

### DIFF
--- a/scenes/Palud/ProtoPalud.tscn
+++ b/scenes/Palud/ProtoPalud.tscn
@@ -809,6 +809,7 @@ parameters/playback = SubResource( 16 )
 
 [node name="Baker3" parent="YSort/NPC" instance=ExtResource( 8 )]
 position = Vector2( 29, 278 )
+InitDir = 0
 AutoDialogueID = "testApproach"
 DemandDialogueID = "demandBaker"
 
@@ -823,6 +824,7 @@ parameters/playback = SubResource( 17 )
 
 [node name="Baker2" parent="YSort/NPC" instance=ExtResource( 8 )]
 position = Vector2( 453, 298 )
+InitDir = 0
 AutoDialogueID = "testApproach"
 DemandDialogueID = "demandRandom"
 
@@ -889,11 +891,12 @@ parameters/playback = SubResource( 20 )
 
 [node name="OldMan" parent="YSort/NPC" instance=ExtResource( 8 )]
 position = Vector2( 301, 325 )
-ProbRight = 1
-ProbLeft = 1
-ProbUp = 0
-ProbDown = 0
+ProbRight = 5
+ProbLeft = 5
+ProbUp = 1
+ProbDown = 1
 CanWander = true
+WalkSpeed = 25
 AutoDialogueID = ""
 DemandDialogueID = "demandOldMan"
 HasAutoDialogue = false
@@ -1052,9 +1055,6 @@ visible = false
 [node name="Label" parent="YSort/Affiche/Sprite" index="0"]
 text = "Regarder"
 
-[node name="AnimatedSprite" parent="YSort/Affiche/Sprite" index="1"]
-frame = 0
-
 [node name="Open" parent="YSort/Affiche" index="2"]
 visible = false
 
@@ -1208,6 +1208,7 @@ texture = ExtResource( 39 )
 [node name="PressE" parent="YSort/Affiche/Open" index="11" instance=ExtResource( 40 )]
 position = Vector2( -38, 155 )
 scale = Vector2( 1, 1 )
+frame = 1
 
 [node name="Notebook" parent="." instance=ExtResource( 15 )]
 visible = false


### PR DESCRIPTION
This is the only solution I was able to find for issue #69.  
The idea is that the initial direction of NPCs can be set in-editor with `InitDir`.    